### PR TITLE
Added export option for tcx files. Closes #37

### DIFF
--- a/hook/extension/js/modifiers/RemoteLinksModifier.js
+++ b/hook/extension/js/modifiers/RemoteLinksModifier.js
@@ -55,6 +55,10 @@ RemoteLinksModifier.prototype = {
         htmlRemoteViewForActivity += "</li>";
         htmlRemoteViewForActivity = jQuery(htmlRemoteViewForActivity);
         jQuery("#pagenav").append(htmlRemoteViewForActivity);
+
+        // Add tcx export
+        var htmlForTCXExport = "<li><a href='" + window.location.pathname + "/export_tcx'>Export TCX</a></li>";
+        jQuery(".actions-menu .slide-menu .options").append(htmlForTCXExport);
     },
 
     /**


### PR DESCRIPTION
As detailed in #37 , this adds an option to export tcx files from an activity page. tcx files also contain heart rate data. The tcx export itself is provided by Strava in a method referenced in their documentation at:  https://strava.zendesk.com/entries/22555481-Exporting-your-Data-and-Bulk-Export